### PR TITLE
update bindgen to v0.58.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ keywords = ["graphviz", "dot", "ffi", "C", "graph"]
 categories = ["external-ffi-bindings", "visualization"]
 
 [build-dependencies]
-bindgen = "0.54.1"
+bindgen = "0.58.1"


### PR DESCRIPTION
I noticed that `graphviz-ffi` won't build with bindgen v0.54.1. This pr simply updates bindgen to the latest version (v0.58.1). 